### PR TITLE
Refresh and Deactivate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 .tmp
+.vscode

--- a/src/app.ts
+++ b/src/app.ts
@@ -20,7 +20,7 @@ import ViewWrapper from './view_wrapper';
 export const PARENT = Symbol.for('@delegate/parent');
 
 export interface MessageConstructor {
-  new(): Message;
+  new(data?: any, opts?: any): Message;
 }
 
 export type MessageOrEmpty = Message | false | null | undefined;

--- a/src/message.ts
+++ b/src/message.ts
@@ -51,3 +51,5 @@ export default class Message {
 }
 
 export class Activate extends Message {}
+export class Refresh extends Message {}
+export class Deactivate extends Message {}

--- a/src/view_wrapper.tsx
+++ b/src/view_wrapper.tsx
@@ -1,7 +1,7 @@
 import * as PropTypes from 'prop-types';
 import { equals, keys, merge, mergeAll, omit, pick } from 'ramda';
 import * as React from 'react';
-import { Container, DelegateDef, Environment } from './app';
+import { Container, DelegateDef, Environment, MessageConstructor } from './app';
 import ErrorComponent from './components/error';
 import ExecContext from './exec_context';
 import { Activate, Deactivate, Refresh } from './message';
@@ -20,6 +20,7 @@ export type ViewWrapperProps<M> = {
  * This component looks for `execContext` in its parent context, and propagates
  * itself with `execContext` in its children's contexts.
  */
+
 export default class ViewWrapper<M> extends React.PureComponent<ViewWrapperProps<M>, any> {
 
   public static contextTypes = { execContext: PropTypes.object };
@@ -46,6 +47,13 @@ export default class ViewWrapper<M> extends React.PureComponent<ViewWrapperProps
     return { execContext: this.execContext };
   }
 
+  public dispatchLifecycleMessage<M extends MessageConstructor>(message: M, props: any): boolean {
+    const { container, childProps } = props;
+    return container.accepts(message) &&
+      this.execContext.dispatch(new message(omit(['emit'], childProps), { shallow: true })) &&
+      true;
+  }
+
   public componentWillMount() {
     const parent = this.context.execContext;
     const { container, delegate, env, childProps } = this.props;
@@ -57,26 +65,24 @@ export default class ViewWrapper<M> extends React.PureComponent<ViewWrapperProps
     this.execContext = new ExecContext({ env, parent, container, delegate });
     this.unsubscribe = this.execContext.subscribe(this.setState.bind(this));
 
-    if (container.accepts(Activate)) {
-      this.execContext.dispatch(new Activate(omit(['emit'], childProps), { shallow: true }));
+    if (this.dispatchLifecycleMessage(Activate, this.props)) {
       return;
     }
+
     const state = this.execContext.state();
     this.setState(this.execContext.push(merge(state, pick(keys(state), childProps))));
   }
 
   public componentWillReceiveProps(nextProps) {
     const nextChildProps = nextProps.childProps;
-    const { container, childProps } = this.props;
-    if (!equals(nextChildProps, childProps) && container.accepts(Refresh)) {
-      this.execContext.dispatch(new Refresh(omit(['emit'], nextChildProps), { shallow: true }));
+    const { childProps } = this.props;
+    if (!equals(nextChildProps, childProps)) {
+      this.dispatchLifecycleMessage(Refresh, nextProps);
     }
   }
 
   public componentWillUnmount() {
-    if (this.props.container.accepts(Deactivate)) {
-      this.execContext.dispatch(new Deactivate({ shallow: true }));
-    }
+    this.dispatchLifecycleMessage(Deactivate, this.props);
     this.unsubscribe();
   }
 

--- a/src/view_wrapper_test.tsx
+++ b/src/view_wrapper_test.tsx
@@ -1,11 +1,11 @@
 /* tslint:disable:variable-name */
 import { expect } from 'chai';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import 'mocha';
 import { always, merge } from 'ramda';
 import * as React from 'react';
-import { container } from './app';
-import { Activate } from './message';
+import { container, isolate, PARENT } from './app';
+import { Activate, Deactivate, Refresh } from './message';
 
 describe('ViewWrapper', () => {
 
@@ -60,6 +60,78 @@ describe('ViewWrapper', () => {
         const wrapper = shallow(<Container foo={false} />);
         expect(wrapper.html().includes('foo: true, notFoo: true')).to.be.true;
       });
+    });
+  });
+
+  describe('componentWillRecieveProps', () => {
+
+    describe('updating prop values with refresh', () => {
+      let Container;
+
+      beforeEach(() => {
+        const updater = (state, { foo }) => merge(state, { foo, notFoo: foo === false });
+
+        Container = container({
+          init: always({ foo: true, notFoo: false }),
+          update: [
+            [Activate, updater],
+            [Refresh, updater],
+          ],
+          view: ({ foo, notFoo }) => (
+            <span>
+              {`foo: ${foo ? 'true' : 'false'}, notFoo: ${notFoo ? 'true' : 'false'}`}
+            </span>
+          ),
+        });
+      });
+
+      it('updates foo from true to false', () => {
+        const wrapper = mount(<Container />);
+        wrapper.setProps({ foo: false });
+        expect(wrapper.html().includes('foo: false, notFoo: true')).to.be.true;
+      });
+
+    });
+  });
+
+  describe('componentWillUnmount', () => {
+
+    describe('unmounting child component causes a state change', () => {
+      let ContainerB, ContainerA;
+
+      beforeEach(() => {
+        ContainerB = container({
+          init: state => merge(state, { bar: true }),
+          delegate: PARENT,
+          update: [
+            [Deactivate, state => merge(state, { bar : false })],
+          ],
+          view: ({ bar }) => (
+            <span></span>
+          ),
+        });
+
+        ContainerA = container({
+          init: always({ foo: true }),
+          update: [
+            [Refresh, (state, { foo }) => merge(state, { foo })],
+          ],
+          view: state => (
+            <span>
+              <div>{JSON.stringify(state)}</div>
+              {state.foo && <ContainerB />}
+            </span>
+          ),
+        });
+      });
+
+      it('updates bar from true to false', () => {
+        const wrapper = mount(<ContainerA />);
+        expect(wrapper.html().includes('"bar":true')).to.be.true;
+        wrapper.setProps({ foo: false });
+        expect(wrapper.html().includes('"bar":false')).to.be.true;
+      });
+
     });
   });
 });

--- a/src/view_wrapper_test.tsx
+++ b/src/view_wrapper_test.tsx
@@ -4,7 +4,7 @@ import { mount, shallow } from 'enzyme';
 import 'mocha';
 import { always, merge } from 'ramda';
 import * as React from 'react';
-import { container, isolate, PARENT } from './app';
+import { container, PARENT } from './app';
 import { Activate, Deactivate, Refresh } from './message';
 
 describe('ViewWrapper', () => {


### PR DESCRIPTION
`Refresh` allows the container to preform an update on `componentWillReceiveProps `
`Deactivate` allows the container to preform an update on `componentWillUnmount`

I feel like my test for `Deactivate` is a little hacky, but AFAIK there is no good wait to `isolate` the container, but still use enzyme to render the view. So I did the next best thing.

Also updated the `.gitignore` for `.vscode`