### PR TITLE
Cascade Effect Handlers

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -102,7 +102,7 @@ const toMap = ifElse(is(Array), constructN(1, Map as any), id);
  * @param  {Component} view The view passed to the container
  * @return {Function} Returns the wrapped container view
  */
-const wrapView: <M>(defs: { env: Environment, container: Container<M> }) => any = ({ env, container }) => {
+const wrapView: <M>(defs: { env?: Environment, container: Container<M> }) => any = ({ env, container }) => {
   /* eslint-disable react/prop-types */
   const mergeProps = pipe(defaultTo({}), omit(['delegate']));
 
@@ -157,7 +157,7 @@ export const withEnvironment = curry(<M>(env: Environment, def: ContainerDef<M>)
   return freeze(defineProperty(assign(wrapView({ env, container: ctr }), fns), 'name', { value: ctr.name }));
 });
 
-const defaultEnv: Environment = environment({ effects, dispatcher });
+export const defaultEnv: Environment = environment({ effects, dispatcher });
 
 /**
  * Creates a new container.
@@ -207,7 +207,7 @@ const defaultEnv: Environment = environment({ effects, dispatcher });
  *  - `accepts`: Accepts a message class and returns a boolean indicating whether the container
  *    accepts messages of that type.
  */
-export const container: <M>(def: ContainerDef<M>) => Container<M> = withEnvironment(defaultEnv);
+export const container: <M>(def: ContainerDef<M>) => Container<M> = withEnvironment(null);
 
 /**
  * Returns a copy of a container, disconnected from its effects / command dispatcher.

--- a/src/app.ts
+++ b/src/app.ts
@@ -119,6 +119,8 @@ const mapDef: <M>(def: ContainerDefPartial<M>) => ContainerDefMapped<M> = pipe(
   evolve({ update: toMap, name: defaultTo('UnknownContainer') })
 );
 
+export const defaultLog = console.error.bind(console);
+
 /**
  * Creates an execution environment for a container by providing it with a set of effects
  * handlers and an effect dispatcher.
@@ -138,7 +140,7 @@ const mapDef: <M>(def: ContainerDefPartial<M>) => ContainerDefMapped<M> = pipe(
 export const environment = ({ effects, dispatcher, log = null, stateManager = null }: EnvDef): Environment => ({
   dispatcher: dispatcher(effects),
   identity: () => ({ effects, dispatcher, log, stateManager }),
-  log: log || console.error.bind(console),
+  log: log || defaultLog,
   stateManager: stateManager || (() => new StateManager())
 });
 

--- a/src/exec_context.ts
+++ b/src/exec_context.ts
@@ -202,7 +202,7 @@ export default class ExecContext<M> {
     };
 
     const mergedContainerEnv = (parent?: ExecContext<M>, env?: Environment): Environment => {
-      if (!env && !parent) {
+      if (!env && (!parent || !parent.env)) {
         throw new Error('YOU ARE A MORON');
       }
 

--- a/src/exec_context.ts
+++ b/src/exec_context.ts
@@ -162,7 +162,6 @@ const configureStateManager = (container: Container<any>, env?: Environment): St
   if (!env) {
     return intercept(new StateManager());
   }
-
   return intercept(env.stateManager(container));
 };
 
@@ -203,13 +202,7 @@ export default class ExecContext<M> {
     const run = (msg, [next, cmds]) => {
       notify({ context: this, container, msg, path: this.path, prev: this.getState({ path: [] }), next, cmds });
       this.push(next);
-
-      if (!this.env && cmds) {
-        throw new Error(`An environment is needed in ${this.container.name}`
-                        + `or one of it's parents in order to dispatch commands`);
-      }
-
-      return env ? this.commands(msg, cmds) : true;
+      return this.env ? this.commands(msg, cmds) : true;
     };
 
     const initialize = fn => (...args) => {

--- a/src/exec_context.ts
+++ b/src/exec_context.ts
@@ -152,7 +152,7 @@ const dispatchAction = (exec, messageTypes, action) => {
 };
 
 /**
- * Checks if an enviroment has been bound to a container, and if not returns a default
+ * Checks if an enviroment has been boud to a container, and if not returns a default
  * StateManager
  *
  * @param  {Object} container the container being bound to an ExecContext
@@ -234,7 +234,7 @@ export default class ExecContext<M> {
 
     const containerEnv = mergeContainerEnv(parent, env);
     const wrapInit = (props: string[]) => pipe(pick(props), map(pipe(fn => fn.bind(this), initialize)));
-    const errLog = containerEnv && error(containerEnv.log) || defaultLog;
+    const errLog = containerEnv && error(containerEnv.log) || error(defaultLog);
 
     freeze(assign(this, {
       env: containerEnv,

--- a/src/exec_context.ts
+++ b/src/exec_context.ts
@@ -202,9 +202,14 @@ export default class ExecContext<M> {
 
     const run = (msg, [next, cmds]) => {
       notify({ context: this, container, msg, path: this.path, prev: this.getState({ path: [] }), next, cmds });
-      console.log(next);
       this.push(next);
-      return this.commands(msg, cmds);
+
+      if (!this.env && cmds) {
+        throw new Error(`An environment is needed in ${this.container.name}`
+                        + `or one of it's parents in order to dispatch commands`);
+      }
+
+      return env ? this.commands(msg, cmds) : true;
     };
 
     const initialize = fn => (...args) => {

--- a/src/exec_context.ts
+++ b/src/exec_context.ts
@@ -3,7 +3,7 @@ import {
   merge, mergeAll, mergeDeepWithKey, nth, pick, pickBy, pipe, prop, values
 } from 'ramda';
 
-import { Container, DelegateDef, Environment, environment, PARENT } from './app';
+import { Container, defaultLog, DelegateDef, Environment, environment, PARENT } from './app';
 import { cmdName, intercept, notify } from './dev_tools';
 import Message from './message';
 import StateManager, { Callback, Config } from './state_manager';
@@ -232,12 +232,12 @@ export default class ExecContext<M> {
       return environment(mergeDeepWithKey(mergeEffects, parent.env.identity(), env.identity()));
     };
 
-    const contaierEnv = mergeContainerEnv(parent, env);
+    const containerEnv = mergeContainerEnv(parent, env);
     const wrapInit = (props: string[]) => pipe(pick(props), map(pipe(fn => fn.bind(this), initialize)));
-    const errLog = contaierEnv && error(contaierEnv.log) || (() => { });
+    const errLog = containerEnv && error(containerEnv.log) || defaultLog;
 
     freeze(assign(this, {
-      env: contaierEnv,
+      env: containerEnv,
       path,
       parent,
       errLog,

--- a/src/exec_context.ts
+++ b/src/exec_context.ts
@@ -152,7 +152,7 @@ const dispatchAction = (exec, messageTypes, action) => {
 };
 
 /**
- * Checks if an enviroment has been boud to a container, and if not returns a default
+ * Checks if an enviroment has been bound to a container, and if not returns a default
  * StateManager
  *
  * @param  {Object} container the container being bound to an ExecContext

--- a/src/view_wrapper.tsx
+++ b/src/view_wrapper.tsx
@@ -10,7 +10,7 @@ export type ViewWrapperProps<M> = {
   childProps: M & { emit: (...args: any[]) => any },
   container: Container<M>,
   delegate: DelegateDef,
-  env: Environment
+  env?: Environment
 };
 
 /**
@@ -34,10 +34,10 @@ export default class ViewWrapper<M> extends React.PureComponent<ViewWrapperProps
       PropTypes.string,
       PropTypes.symbol,
       PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string]))]),
-    env: PropTypes.object.isRequired
+    env: PropTypes.object,
   };
 
-  public static defaultProps = { delegate: null };
+  public static defaultProps = { delegate: null, env: null };
 
   public execContext?: ExecContext<M> = null;
 

--- a/src/view_wrapper_test.tsx
+++ b/src/view_wrapper_test.tsx
@@ -2,10 +2,12 @@
 import { expect } from 'chai';
 import { mount, shallow } from 'enzyme';
 import 'mocha';
-import { always, merge } from 'ramda';
+import { always, merge, pipe } from 'ramda';
 import * as React from 'react';
-import { container, PARENT } from './app';
-import { Activate, Deactivate, Refresh } from './message';
+import { container, environment, PARENT, withEnvironment } from './app';
+import dispatcher from './dispatcher';
+import Message, { Activate, Deactivate, Refresh } from './message';
+import { constructMessage, isEmittable } from './util';
 
 describe('ViewWrapper', () => {
 
@@ -130,6 +132,58 @@ describe('ViewWrapper', () => {
         expect(wrapper.html().includes('"bar":true')).to.be.true;
         wrapper.setProps({ foo: false });
         expect(wrapper.html().includes('"bar":false')).to.be.true;
+      });
+
+    });
+  });
+
+  describe('Commands', () => {
+
+    describe('ContainerA environment should casscade to ContainerB', () => {
+      let ContainerB, ContainerA;
+
+      beforeEach(() => {
+        class TestCommand extends Message {
+          public static expects = {
+            result: isEmittable,
+          };
+        }
+
+        class TestCommandResult extends Message {}
+
+        const testEffect = new Map([
+          [TestCommand, ({ result }, dispatch) => pipe(constructMessage(result), dispatch)({})]
+        ]);
+
+        ContainerB = container({
+          init: state => merge(state, { bar: true }),
+          delegate: PARENT,
+          update: [
+            [Activate, state => [
+              merge(state, { bar: false }),
+              new TestCommand({ result: TestCommandResult }),
+            ]],
+            [TestCommandResult, state => merge(state, { bar: true })]
+          ],
+          view: () => (
+            <span></span>
+          ),
+        });
+
+        ContainerA = withEnvironment(environment({ effects: testEffect, dispatcher }),{
+          init: always({ foo: true }),
+          view: state => (
+            <span>
+              <div>{JSON.stringify(state)}</div>
+              <ContainerB />
+            </span>
+          ),
+        });
+      });
+
+      it('updates bar from true to false, and then back to true', () => {
+        const wrapper = mount(<ContainerA />);
+        expect(wrapper.html().includes('"bar":true')).to.be.true;
       });
 
     });


### PR DESCRIPTION
- Decoupled `Environment` from `Container` so by default when you export `container` is has no environment.

- If a `Container` has no parent, and no `Environment` it defaults the `stateManager` in `exec_context`

- Made `defaultEnv` an export so the user can use it if needed.

- Wrote a test where `ContainerA` has an environment with `TestCommand` and `ContainerB` dispatches `TestCommand` that triggers a result `Message` to change state

If you think of any additional test cases please let me know.