### PR TITLE
Isolate bug in mergeEnv fixed

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -46,12 +46,12 @@ export const environment = ({ effects, dispatcher, log = null, stateManager = nu
 export const mergeEnv = <M>(
   parent?: ExecContext<M> | ExecContextPartial,
   env?: Environment): Environment => {
-  if (env && parent instanceof ExecContext) {
+  if (env && parent instanceof ExecContext && parent.env) {
     const mergeEffects = (k, l, r) => k === 'effects' ? mergeMap(l, r) : r;
     return environment(mergeDeepWithKey(mergeEffects, parent.env.identity(), env.identity()));
-  } else if (!env && parent instanceof ExecContext) {
+  } else if (!env && parent instanceof ExecContext && parent.env) {
     return parent.env;
-  } else if (env && !parent) {
+  } else if (env && (!parent || !(parent instanceof ExecContext) || !parent.env)) {
     return env;
   }
 

--- a/src/view_wrapper.tsx
+++ b/src/view_wrapper.tsx
@@ -60,7 +60,7 @@ export default class ViewWrapper<M> extends React.PureComponent<ViewWrapperProps
     const { container, delegate, env, childProps } = this.props;
 
     if (delegate && !parent) {
-      const msg = `Attempting to delegate state property '${delegate}' with no parent container`;
+      const msg = `Attempting to delegate state property '${delegate.toString()}' with no parent container`;
       console.warn(msg); // tslint:disable-line:no-console
     }
     this.execContext = new ExecContext({ env, parent, container, delegate });


### PR DESCRIPTION
It seems as though  in`mergeEnv` `parent instanceof ExecContext` was showing true if it was 
 of type `ExecContextPartial`. Also needed to make `delegate.toString()` to be able to print symbol. Whoops!

@nateabele any reason as to why `parent instanceof ExecContext` was triggering true for isolate?