### PR TITLE
Relay passed in view_wrapper to view

### DIFF
--- a/src/view_wrapper.tsx
+++ b/src/view_wrapper.tsx
@@ -99,7 +99,7 @@ export default class ViewWrapper<M> extends React.PureComponent<ViewWrapperProps
     }
     // tslint:disable-next-line:variable-name
     const Child = (this.props.container as any).view, ctx = this.execContext;
-    const props = mergeAll([this.props.childProps, ctx.state(), { emit: ctx.emit.bind(ctx) }]);
+    const props = mergeAll([this.props.childProps, ctx.state(), { emit: ctx.emit.bind(ctx) }, { relay: ctx.relay() }]);
     return <Child {...props} />;
   }
 }


### PR DESCRIPTION
This got missed in porting features from `architecture` to `casium`. 