### PR TITLE
Refresh Moved to componentDidUpdate

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casium",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Casium — An application architecture for React",
   "module": "./dist/index.js",
   "types": "./dist/main.d.ts",

--- a/src/view_wrapper.tsx
+++ b/src/view_wrapper.tsx
@@ -74,11 +74,11 @@ export default class ViewWrapper<M> extends React.PureComponent<ViewWrapperProps
     this.setState(this.execContext.push(merge(state, pick(keys(state), childProps))));
   }
 
-  public componentWillReceiveProps(nextProps) {
-    const nextChildProps = nextProps.childProps;
+  public componentDidUpdate(prevProps) {
+    const prevChildProps = prevProps.childProps;
     const { childProps } = this.props;
-    if (!equals(nextChildProps, childProps)) {
-      this.dispatchLifecycleMessage(Refresh, nextProps);
+    if (!equals(prevChildProps, childProps)) {
+      this.dispatchLifecycleMessage(Refresh, childProps);
     }
   }
 

--- a/src/view_wrapper.tsx
+++ b/src/view_wrapper.tsx
@@ -78,7 +78,7 @@ export default class ViewWrapper<M> extends React.PureComponent<ViewWrapperProps
     const prevChildProps = prevProps.childProps;
     const { childProps } = this.props;
     if (!equals(prevChildProps, childProps)) {
-      this.dispatchLifecycleMessage(Refresh, childProps);
+      this.dispatchLifecycleMessage(Refresh, this.props);
     }
   }
 

--- a/src/view_wrapper_test.tsx
+++ b/src/view_wrapper_test.tsx
@@ -66,7 +66,7 @@ describe('ViewWrapper', () => {
     });
   });
 
-  describe('componentWillRecieveProps', () => {
+  describe('componentDidUpdate', () => {
 
     describe('updating prop values with refresh', () => {
       let Container;


### PR DESCRIPTION
So `Refresh` does not break with React 16. 