### PR TITLE
Omitting children from Activate, Deactivate, Refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casium",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Casium — An application architecture for React",
   "module": "./dist/index.js",
   "types": "./dist/main.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casium",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Casium — An application architecture for React",
   "module": "./dist/index.js",
   "types": "./dist/main.d.ts",

--- a/src/view_wrapper.tsx
+++ b/src/view_wrapper.tsx
@@ -51,7 +51,7 @@ export default class ViewWrapper<M> extends React.PureComponent<ViewWrapperProps
   public dispatchLifecycleMessage<M extends MessageConstructor>(message: M, props: any): boolean {
     const { container, childProps } = props;
     return container.accepts(message) &&
-      this.execContext.dispatch(new message(omit(['emit'], childProps), { shallow: true })) &&
+      this.execContext.dispatch(new message(omit(['emit', 'children'], childProps), { shallow: true })) &&
       true;
   }
 
@@ -77,7 +77,8 @@ export default class ViewWrapper<M> extends React.PureComponent<ViewWrapperProps
   public componentDidUpdate(prevProps) {
     const prevChildProps = prevProps.childProps;
     const { childProps } = this.props;
-    if (!equals(prevChildProps, childProps)) {
+    const omitChildren = omit(['children']);
+    if (!equals(omitChildren(prevChildProps), omitChildren(childProps))) {
       this.dispatchLifecycleMessage(Refresh, this.props);
     }
   }


### PR DESCRIPTION
With React 16 children now have a property of `_owner` that has a bunch of unique data that was failing when comparing old and new props. Causing in our app weird side effects. We talked about this slightly via slack yesterday @nateabele. OH and I had to bump version by 2 since I was dumb and did not do the last publish from `/dist` . 😢 