### PR TITLE
Expose Context ID on Messages sent to DevTools

### DIFF
--- a/src/dev_tools.ts
+++ b/src/dev_tools.ts
@@ -83,6 +83,7 @@ export const notify = ({ context, msg, prev, next, path, cmds }: DevToolsMessage
   const { container } = context;
 
   const serialized = serialize({
+    context: context.id,
     id: session + _ARCH_DEV_TOOLS_STATE.next(),
     name: container.name,
     ts: Date.now(),


### PR DESCRIPTION
Exposes `context.id` on a Message as `context` in the serialized data that is sent to the devtools extension. This allows for an upcoming feature in devtools that requires the context to be known.