### PR TITLE
Support axios 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "webpack-node-externals": "1.6.0"
   },
   "peerDependencies": {
-    "axios": "^0.16.0",
+    "axios": "^0.16.0 || ^0.17.0",
     "deep-freeze-strict": "^1.1.0",
     "history": "^4.6.0",
     "js-cookie": "^2.1.4",


### PR DESCRIPTION
Axiom is using axios 17 (causing a casium peer dependency warning), and I doubt there is a reason that we need exactly axios 0.16 here, so I figured I'd add this guy too.