### PR TITLE
Call run() on containers without an `init` function

### DIFF
--- a/src/core_test.tsx
+++ b/src/core_test.tsx
@@ -71,7 +71,7 @@ describe('app', () => {
     });
 
     describe('subscriptions', () => {
-      it('is called with the new model value after every Updater', () => {
+      it('is called with the new model value after init and every Updater', () => {
         const log = [];
 
         const ctr = isolate(container({
@@ -86,6 +86,7 @@ describe('app', () => {
         ctr.dispatch(new Msg({ count: 'two' }));
 
         expect(log).to.deep.equal([
+          {},
           { test: 'one' },
           { test: 'two' }
         ]);

--- a/src/runtime/exec_context.ts
+++ b/src/runtime/exec_context.ts
@@ -177,11 +177,11 @@ export default class ExecContext<M> {
     };
 
     const initialize = fn => (...args) => {
-      if (!hasInitialized && container.init) {
+      if (!hasInitialized) {
         hasInitialized = true;
         const { attach } = container, hasStore = attach && attach.store;
         const initial = hasStore ? attachStore(container.attach, container) : (this.getState() || {});
-        run(null, mapResult(container.init(initial, parent && parent.relay() || {}) || {}));
+        run(null, mapResult((container.init || identity)(initial, parent && parent.relay() || {}) || {}));
       }
       return fn.call(this, ...args);
     };


### PR DESCRIPTION
@nateabele As far as I can tell, the change to subscription behaviour (as seen in the change to the unit test) is correct, but let me know if notification to subscribers should be skipped on init.