### PR TITLE
Extract reducer used by 'seq' to 'reduceUpdater' util function

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -9,7 +9,7 @@ import { create, Environment, root } from './environment';
 import Message, { MessageConstructor } from './message';
 import ExecContext from './runtime/exec_context';
 import StateManager from './runtime/state_manager';
-import { mapResult } from './util';
+import { mapResult, reduceUpdater } from './util';
 import ViewWrapper from './view_wrapper';
 
 /**
@@ -193,9 +193,9 @@ export const isolate = <M>(ctr: Container<M>, opts: any = {}): IsolatedContainer
 export function seq<M>(...updaters: Updater<M>[]) {
   return function (model: M, msg?: GenericObject, relay?: GenericObject): UpdateResult<M> {
     const merge = ([{}, cmds], [newModel, newCmds]) => [newModel, flatten(cmds.concat(newCmds))];
-    const reduce = (prev, cur) => is(Function, cur)
-      ? reduce(prev, cur(prev[0], msg, relay))
-      : merge(prev, mapResult(cur));
+    const reduce = (prev, cur) =>
+      merge(prev, mapResult(reduceUpdater(cur, prev[0], msg, relay)));
+
     return updaters.reduce(reduce, [model, []]) as UpdateResult<M>;
   };
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -67,7 +67,11 @@ export type Container<M> = ContainerView<M> & ContainerPartial<M> & ContainerDef
   accepts: (m: MessageConstructor) => boolean;
   identity: () => ContainerDef<M>;
 };
-export type IsolatedContainer<M> = Container<M> & { dispatch: any };
+export type IsolatedContainer<M> = Container<M> & {
+  dispatch: any;
+  state: () => M;
+  push: (state: M) => void;
+};
 
 const { freeze, assign, defineProperty } = Object;
 

--- a/src/runtime/exec_context.ts
+++ b/src/runtime/exec_context.ts
@@ -7,7 +7,7 @@ import { Container, DelegateDef, PARENT } from '../core';
 import { cmdName, intercept, notify } from '../dev_tools';
 import * as Environment from '../environment';
 import Message, { MessageConstructor } from '../message';
-import { mapResult, replace, safeStringify, toArray, trap } from '../util';
+import { mapResult, reduceUpdater, replace, safeStringify, toArray, trap } from '../util';
 import StateManager, { Callback, Config } from './state_manager';
 
 export type ExecContextPartial = { relay: () => object, state?: (cfg?: object) => object, path?: string[] };
@@ -89,7 +89,8 @@ const mapMessage = (handler, state, msg, relay) => {
   if (!handler || !is(Function, handler)) {
     throw new TypeError(`Invalid handler for message type '${msg.constructor.name}'`);
   }
-  return mapResult(handler(state, msg.data, relay));
+
+  return mapResult(reduceUpdater(handler, state, msg.data, relay));
 };
 
 /**

--- a/src/util.ts
+++ b/src/util.ts
@@ -185,3 +185,8 @@ export const mapResult = cond([
   [is(Object), state => [freezeObj(state), []]],
   [always(true), (val) => { throw new TypeError('Unrecognized structure ' + safeStringify(val)); }],
 ]);
+
+export const reduceUpdater = (value, state, msg, relay) =>
+  is(Function, value)
+    ? reduceUpdater(value(state, msg, relay), state, msg, relay)
+    : value;


### PR DESCRIPTION
Allows the recursive behaviour allowed by 'seq' to be used by 'mapMessage'. This encourages updaters such as:

```
[Msg, (model, msg) => evolve({count: inc(msg.step)}, model)]
```

To be refactored to:

```
[Msg, (model, msg) => evolve({count: inc(msg.step)})]
```