### PR TITLE
Use Decorators to explicitly prefix Command Constructor names

### DIFF
--- a/src/commands/browser.ts
+++ b/src/commands/browser.ts
@@ -1,17 +1,22 @@
 import { is } from 'ramda';
 import Message from '../message';
+import { moduleName } from '../util';
 
+@moduleName('Browser')
 export class ReplaceHistory extends Message {
   public static expects = { path: is(String) };
 }
 
+@moduleName('Browser')
 export class PushHistory extends Message {
   public static expects = { path: is(String) };
 }
 
+@moduleName('Browser')
 export class Back extends Message {
 }
 
+@moduleName('Browser')
 export class Timeout extends Message {
   public static expects = { result: Message.isEmittable, timeout: is(Number) };
 }

--- a/src/commands/cookies.ts
+++ b/src/commands/cookies.ts
@@ -1,10 +1,13 @@
 import { either as or, is, isNil } from 'ramda';
 import Message from '../message';
+import { moduleName } from '../util';
 
+@moduleName('Cookies')
 export class Read extends Message {
   public static expects = { key: is(String), result: Message.isEmittable };
 }
 
+@moduleName('Cookies')
 export class Write extends Message {
   public static expects = {
     expires: or(is(Date), isNil),
@@ -14,6 +17,7 @@ export class Write extends Message {
   };
 }
 
+@moduleName('Cookies')
 export class Delete extends Message {
   public static expects = { key: is(String) };
 }

--- a/src/commands/cookies_test.ts
+++ b/src/commands/cookies_test.ts
@@ -13,7 +13,7 @@ describe('cookies', () => {
 
     it('result does not accept a function', () => {
       expect(() => new Cookies.Read({ key: 'bleh', result: () => {} }))
-        .to.throw(TypeError, /failed expectations in Read: result/);
+        .to.throw(TypeError, /failed expectations in Cookies.Read: result/);
     });
   });
 });

--- a/src/commands/http.ts
+++ b/src/commands/http.ts
@@ -1,6 +1,8 @@
 import { either as or, is, keys } from 'ramda';
 import Message from '../message';
+import { moduleName } from '../util';
 
+@moduleName('HTTP')
 export class Request extends Message {
   public static defaults = { method: null, url: null, data: {}, params: {}, headers: {} };
   public static expects = {
@@ -14,30 +16,37 @@ export class Request extends Message {
   };
 }
 
+@moduleName('HTTP')
 export class Post extends Request {
   public static defaults = { method: 'POST', url: null, data: {}, params: {}, headers: {} };
 }
 
+@moduleName('HTTP')
 export class Get extends Request {
   public static defaults = { method: 'GET', url: null, data: {}, params: {}, headers: {} };
 }
 
+@moduleName('HTTP')
 export class Put extends Request {
   public static defaults = { method: 'PUT', url: null, data: {}, params: {}, headers: {} };
 }
 
+@moduleName('HTTP')
 export class Head extends Request {
   public static defaults = { method: 'HEAD', url: null, data: {}, params: {}, headers: {} };
 }
 
+@moduleName('HTTP')
 export class Delete extends Request {
   public static defaults = { method: 'DELETE', url: null, data: {}, params: {}, headers: {} };
 }
 
+@moduleName('HTTP')
 export class Options extends Request {
   public static defaults = { method: 'OPTIONS', url: null, data: {}, params: {}, headers: {} };
 }
 
+@moduleName('HTTP')
 export class Patch extends Request {
   public static defaults = { method: 'PATCH', url: null, data: {}, params: {}, headers: {} };
 }

--- a/src/commands/http_test.ts
+++ b/src/commands/http_test.ts
@@ -16,7 +16,7 @@ describe('http', () => {
     it('result does not accept a function', () => {
       expect(() => new Request({
         method: 'GET', url: '/', result: () => {}, error: TestMessage
-      })).to.throw(TypeError, /failed expectations in Request: result/);
+      })).to.throw(TypeError, /failed expectations in HTTP.Request: result/);
     });
   });
 
@@ -30,7 +30,7 @@ describe('http', () => {
     it('error does not accept a function', () => {
       expect(() => new Request({
         method: 'GET', url: '/', result: TestMessage, error: () => {}
-      })).to.throw(TypeError, /failed expectations in Request: error/);
+      })).to.throw(TypeError, /failed expectations in HTTP.Request: error/);
     });
   });
 });

--- a/src/commands/local_storage.ts
+++ b/src/commands/local_storage.ts
@@ -1,18 +1,23 @@
 import { complement as not, is, isNil } from 'ramda';
 import Message from '../message';
+import { moduleName } from '../util';
 
+@moduleName('LocalStorage')
 export class Read extends Message {
   public static expects = { key: is(String), result: Message.isEmittable };
 }
 
+@moduleName('LocalStorage')
 export class Write extends Message {
   public static expects = { key: is(String), value: not(isNil) };
 }
 
+@moduleName('LocalStorage')
 export class Delete extends Message {
   public static expects = { key: is(String) };
 }
 
+@moduleName('LocalStorage')
 export class Clear extends Message {
   public static expects = {};
 }

--- a/src/runtime/exec_context.ts
+++ b/src/runtime/exec_context.ts
@@ -3,7 +3,6 @@ import {
   identity, is, isEmpty, keys, map, merge, nth, pick, pipe, prop, values
 } from 'ramda';
 
-import * as commands from '../commands';
 import { Container, DelegateDef, PARENT } from '../core';
 import * as Environment from '../environment';
 import { intercept, notify } from '../instrumentation';
@@ -140,16 +139,6 @@ const groupEffects = keyFn => (prev, current) => {
  * and will change significantly in the near future.
  */
 export const cmdName = (cmd) => {
-  let mod, name, cls;
-
-  for (mod in commands) {
-    for (name in commands[mod]) {
-      cls = commands[mod][name];
-      if (cmd && cmd.constructor && cls === cmd.constructor) {
-        return `${mod}.${name}`;
-      }
-    }
-  }
   return cmd && cmd.constructor && cmd.constructor.name || '??';
 };
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,9 +1,15 @@
 import * as deepFreeze from 'deep-freeze-strict';
 import {
-  all, always, both, cond, curry, equals, evolve, filter, flip, identity, ifElse, is, keys, map,
-  merge, mergeDeepWith, not, nth, pickAll, pipe, propEq, reduce, union, when, zipWith
+  all, always, both, cond, curry, equals, evolve, filter, flip, identity,
+  ifElse, is, keys, map, merge, mergeDeepWith, not, nth, pickAll, pipe, propEq,
+  reduce, union, when, zipWith
 } from 'ramda';
 import * as React from 'react';
+
+// tslint:disable-next-line:ban-types
+export const moduleName = (prefix: string) => (constructor: Function) => {
+  Object.defineProperty(constructor, 'name', { value: `${prefix}.${constructor.name}` });
+};
 
 /**
  * Deep-merges two objects, overwriting left-hand keys with right-hand keys, unionizing arrays.


### PR DESCRIPTION
Adds a `moduleName` decorator the the `util` module, which allows the `name` property of a class' Constructor to be prepended with a string.

This allows the built-in Effect classes a way to expose the module they belong to, and greatly simplifies the implementation of `cmdName` and removes the need to enumerate the built-in Effect classes.

---

This PR targets the `next` branch due to BC break