### PR TITLE
Perform prop & state comparison in `ViewWrapper`

### DIFF
--- a/src/view_wrapper.tsx
+++ b/src/view_wrapper.tsx
@@ -73,6 +73,13 @@ export default class ViewWrapper<M> extends React.Component<ViewWrapperProps<M>,
     this.setState(this.execContext.push(merge(state, pick(keys(state), childProps))));
   }
 
+  public shouldComponentUpdate(nextProps, nextState) {
+    return (
+      !equals(nextProps.childProps, this.props.childProps) ||
+      !equals(nextState, this.state)
+    );
+  }
+
   public componentDidUpdate(prev) {
     const { childProps } = this.props;
     const omitChildren = omit(['children']);


### PR DESCRIPTION
Uses `equals` to prevent superfluous renders of components when props and state are equivalent by value.