### PR TITLE
Chore/better testing

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -9,7 +9,7 @@ import { create, Environment, root } from './environment';
 import Message, { MessageConstructor } from './message';
 import ExecContext from './runtime/exec_context';
 import StateManager from './runtime/state_manager';
-import { mapResult, reduceUpdater } from './util';
+import { log, mapResult, reduceUpdater } from './util';
 import ViewWrapper from './view_wrapper';
 
 /**
@@ -182,7 +182,7 @@ export const container: <M>(def: ContainerDef<M>) => Container<M> = withEnvironm
  */
 export const isolate = <M>(ctr: Container<M>, opts: any = {}): IsolatedContainer<M> => {
   const stateManager = opts.stateManager && always(opts.stateManager) || (() => new StateManager());
-  const env = create({ dispatcher: nthArg(2), effects: new Map(), log: () => {}, stateManager });
+  const env = create({ dispatcher: nthArg(2), effects: new Map(), log, stateManager });
 
   const container = assign(mapDef(ctr.identity()), { accepts: always(true) }) as Container<M>;
   const parent: any = opts.relay ? { relay: always(opts.relay) } : null;

--- a/src/runtime/exec_context.ts
+++ b/src/runtime/exec_context.ts
@@ -216,7 +216,7 @@ export default class ExecContext<M> {
   }
 
   public dispatch(message: Message) {
-    return trap(this.errLog(null), this.internalDispatch.bind(this))(checkMessage(this, message));
+    return trap(this.errLog(message), this.internalDispatch.bind(this))(checkMessage(this, message));
   }
 
   public commands(msg, cmds) {

--- a/src/runtime/exec_context.ts
+++ b/src/runtime/exec_context.ts
@@ -216,7 +216,7 @@ export default class ExecContext<M> {
   }
 
   public dispatch(message: Message) {
-    return trap(this.errLog(message), this.internalDispatch.bind(this))(checkMessage(this, message));
+    return trap(this.errLog(null), this.internalDispatch.bind(this))(checkMessage(this, message));
   }
 
   public commands(msg, cmds) {

--- a/src/view_wrapper.tsx
+++ b/src/view_wrapper.tsx
@@ -94,7 +94,7 @@ export default class ViewWrapper<M> extends React.Component<ViewWrapperProps<M>,
     this.execContext.destroy();
   }
 
-  public unstable_handleError(e) {
+  public componentDidCatch(e) {
     // tslint:disable-next-line:no-console
     console.error('Failed to compile React component\n', e);
     this.setState({ componentError: e });


### PR DESCRIPTION
Gave `isolate` a log, instead of it being a no-op.

Also turned `unstable_handleError` to `componentDidCatch` as `casium` uses React 16.