### PR TITLE
Improved Error Handling & Reporting

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -1,8 +1,8 @@
 import * as deepFreeze from 'deep-freeze-strict';
 import {
-  all, always, both, cond, curry, equals, evolve, filter, flip, identity,
-  ifElse, is, keys, map, merge, mergeDeepWith, not, nth, pickAll, pipe, propEq,
-  reduce, union, when, zipWith
+  __, all, always, both, cond, curry, equals, evolve, filter, flip, identity,
+  ifElse, is, keys, map, merge, mergeDeepWith, not, nth, pathOr, pickAll, pipe,
+  propEq, reduce, union, when, zipWith
 } from 'ramda';
 import * as React from 'react';
 
@@ -139,7 +139,7 @@ export const trap: Trap = curry((handler, fn) => ((...args) => {
   try {
     return fn(...args);
   } catch (e) {
-    return handler(args, e);
+    return handler(e, ...args);
   }
 }));
 
@@ -197,3 +197,27 @@ export const reduceUpdater = (value, state, msg, relay) =>
   is(Function, value)
     ? reduceUpdater(value(state, msg, relay), state, msg, relay)
     : value;
+
+/**
+ * Generic helper function for resolving the `name` of an Instance's Constructor
+ * function
+ */
+const ctorName = pathOr(__, ['constructor', 'name']);
+
+/**
+ * Gets the `name` of a Message instance, or defaults to `{INIT}` for nameless
+ * Messages (ie, those called during container initialization)
+ */
+export const msgName = ctorName('{INIT}');
+
+/**
+ * Gets the `name` of a Command Message instance. A nameless Command Message
+ * typically indicates an error.
+ */
+export const cmdName = ctorName('??');
+
+/**
+ * Gets the `name` of a Container if it exists, or defaults to `{Anonymous
+ * Container}` in cases where an explicit name has not been given.
+ */
+export const contextContainerName = pathOr('{Anonymous Container}', ['container', 'name']);

--- a/src/view_wrapper.tsx
+++ b/src/view_wrapper.tsx
@@ -98,9 +98,18 @@ export default class ViewWrapper<M> extends React.Component<ViewWrapperProps<M>,
     this.execContext.destroy();
   }
 
+  public componentDidCatch(e) {
+    this.handleError(e);
+  }
+
   public unstable_handleError(e) {
+    this.handleError(e);
+  }
+
+  public handleError(e) {
+    const { container } = this.props;
     // tslint:disable-next-line:no-console
-    console.error('Failed to compile React component\n', e);
+    console.error(`Error rendering view for container '${container.name}' -- `, e);
     this.setState({ componentError: e });
   }
 


### PR DESCRIPTION
This PR addresses the points raised in #55, with the exception of the fifth point (DevTools integration).

- The old behaviour of `trap` has been restored, which spreads the rest'ed input parameters to the error handler function, meaning that those useless error messages about arrays have now gone away.

- Due to the awkward arrangement of parameters given to the error logging function, I've separated them into two different functions. In this case, I'm willing to sacrifice some repetition in order to make the execution path easier to understand.

- I've hoisted the functions that extract message/command constructor names out to the `util` module. They seem to be more at home there.

- The ViewWrapper error handling has been extracted to another method so that we can support both `unstable_handleError` and `componentDidCatch`.