### PR TITLE
Properly type withProps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "casium",
-  "version": "2.1.1",
+  "version": "2.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casium",
-  "version": "2.1.5",
+  "version": "2.2.1",
   "description": "Casium — An application architecture for React",
   "module": "./index.js",
   "browser": "dist/casium.umd.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casium",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Casium — An application architecture for React",
   "module": "./index.js",
   "browser": "dist/casium.umd.js",

--- a/src/containers/input.tsx
+++ b/src/containers/input.tsx
@@ -18,7 +18,7 @@ export default container({
     [Change, (state, { name, value }) => assoc(name, value, state)],
   ],
 
-  view: withProps({ name }, ({ emit, name, children, ...props }) => (
+  view: withProps({ name }, ({ emit, name, children, ...props }: any) => (
     <span>
       {cloneRecursive(children, {
         ...omit([name], props),

--- a/src/util.ts
+++ b/src/util.ts
@@ -84,17 +84,18 @@ export const getValidationFailures = spec => pipe(
  * <Name first="Bob" last="Loblaw" />
  * ```
  */
-export type ComputeProps<Props, ComputedProps> = { [K in keyof ComputedProps]: (props: Props) => ComputedProps[K] };
-export function withProps<Props extends {}, ComputedProps extends {}>(
-   computeProps: ComputeProps<Props, ComputedProps>,
-   component: React.StatelessComponent<Props & ComputedProps>
-): React.StatelessComponent<Props> {
-  return curry((
-    fnMap: { [key: string]: (props: object) => any },
-    component: React.StatelessComponent<any>,
-    props: object
-  ): JSX.Element => component(mergeDeep(props, map(fn => fn(props), fnMap))));
-}
+ export type PropMap<Input, Generated> = {
+   [K in keyof Generated]: (props: Input) => Generated[K]
+ };
+ type withProps<Input extends {}, Generated extends {}> = (
+   input: PropMap<Input, Generated>,
+   component: React.StatelessComponent<Input & Generated>
+ ) => React.StatelessComponent<Input>;
+export const withProps = curry((
+  fnMap: { [key: string]: (props: object) => any },
+  component: React.StatelessComponent<any>,
+  props: object
+): JSX.Element => component(mergeDeep(props, map(fn => fn(props), fnMap))));
 
 export const cloneRecursive = (children, newProps) => React.Children.map(children, (child) => {
   const mapProps = (child) => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -84,11 +84,17 @@ export const getValidationFailures = spec => pipe(
  * <Name first="Bob" last="Loblaw" />
  * ```
  */
-export const withProps = curry((
-  fnMap: { [key: string]: (props: object) => any },
-  component: React.StatelessComponent<any>,
-  props: object
-): JSX.Element => component(mergeDeep(props, map(fn => fn(props), fnMap))));
+ export type DeriveProps<Props, DerivedProps> = { [K in keyof DerivedProps]: (props: Props) => DerivedProps[K] };
+ export function withProps<Props extends {}, DerivedProps extends {}>(
+   deriveProps: DeriveProps<Props, DerivedProps>,
+   component: React.StatelessComponent<Props & DerivedProps>
+ ): React.StatelessComponent<Props> {
+   return curry((
+     fnMap: { [key: string]: (props: object) => any },
+     component: React.StatelessComponent<any>,
+     props: object
+   ): JSX.Element => component(mergeDeep(props, map(fn => fn(props), fnMap))))
+};
 
 export const cloneRecursive = (children, newProps) => React.Children.map(children, (child) => {
   const mapProps = (child) => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -84,10 +84,10 @@ export const getValidationFailures = spec => pipe(
  * <Name first="Bob" last="Loblaw" />
  * ```
  */
- export type DeriveProps<Props, DerivedProps> = { [K in keyof DerivedProps]: (props: Props) => DerivedProps[K] };
- export function withProps<Props extends {}, DerivedProps extends {}>(
-   deriveProps: DeriveProps<Props, DerivedProps>,
-   component: React.StatelessComponent<Props & DerivedProps>
+ export type ComputeProps<Props, ComputedProps> = { [K in keyof ComputedProps]: (props: Props) => ComputedProps[K] };
+ export function withProps<Props extends {}, ComputedProps extends {}>(
+   computeProps: ComputeProps<Props, ComputedProps>,
+   component: React.StatelessComponent<Props & ComputedProps>
  ): React.StatelessComponent<Props> {
    return curry((
      fnMap: { [key: string]: (props: object) => any },

--- a/src/util.ts
+++ b/src/util.ts
@@ -84,17 +84,17 @@ export const getValidationFailures = spec => pipe(
  * <Name first="Bob" last="Loblaw" />
  * ```
  */
- export type ComputeProps<Props, ComputedProps> = { [K in keyof ComputedProps]: (props: Props) => ComputedProps[K] };
- export function withProps<Props extends {}, ComputedProps extends {}>(
+export type ComputeProps<Props, ComputedProps> = { [K in keyof ComputedProps]: (props: Props) => ComputedProps[K] };
+export function withProps<Props extends {}, ComputedProps extends {}>(
    computeProps: ComputeProps<Props, ComputedProps>,
    component: React.StatelessComponent<Props & ComputedProps>
- ): React.StatelessComponent<Props> {
-   return curry((
-     fnMap: { [key: string]: (props: object) => any },
-     component: React.StatelessComponent<any>,
-     props: object
-   ): JSX.Element => component(mergeDeep(props, map(fn => fn(props), fnMap))))
-};
+): React.StatelessComponent<Props> {
+  return curry((
+    fnMap: { [key: string]: (props: object) => any },
+    component: React.StatelessComponent<any>,
+    props: object
+  ): JSX.Element => component(mergeDeep(props, map(fn => fn(props), fnMap))));
+}
 
 export const cloneRecursive = (children, newProps) => React.Children.map(children, (child) => {
   const mapProps = (child) => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -85,17 +85,14 @@ export const getValidationFailures = spec => pipe(
  * ```
  */
 export type PropMap<Input, Generated> = {
-   [K in keyof Generated]: (props: Input) => Generated[K]
- };
-export type WithProps<Input extends {}, Generated extends {}> = (
-   input: PropMap<Input, Generated>,
-   component: React.StatelessComponent<Input & Generated>
- ) => React.StatelessComponent<Input>;
-export const withProps: WithProps = curry((
-  fnMap: { [key: string]: (props: object) => any },
-  component: React.StatelessComponent<any>,
-  props: object
-) => component(mergeDeep(props, map(fn => fn(props), fnMap))));
+  [K in keyof Generated]: (props: Input) => Generated[K]
+};
+export function withProps<Input, Generated>(
+  fnMap: PropMap<Input, Generated>,
+  component: React.StatelessComponent<Input & Generated>
+) {
+  return (props: Input) => component(merge(props, map(fn => fn(props), fnMap)) as Input & Generated);
+}
 
 export const cloneRecursive = (children, newProps) => React.Children.map(children, (child) => {
   const mapProps = (child) => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -84,18 +84,18 @@ export const getValidationFailures = spec => pipe(
  * <Name first="Bob" last="Loblaw" />
  * ```
  */
- export type PropMap<Input, Generated> = {
+export type PropMap<Input, Generated> = {
    [K in keyof Generated]: (props: Input) => Generated[K]
  };
- type withProps<Input extends {}, Generated extends {}> = (
+export type WithProps<Input extends {}, Generated extends {}> = (
    input: PropMap<Input, Generated>,
    component: React.StatelessComponent<Input & Generated>
  ) => React.StatelessComponent<Input>;
-export const withProps = curry((
+export const withProps: WithProps = curry((
   fnMap: { [key: string]: (props: object) => any },
   component: React.StatelessComponent<any>,
   props: object
-): JSX.Element => component(mergeDeep(props, map(fn => fn(props), fnMap))));
+) => component(mergeDeep(props, map(fn => fn(props), fnMap))));
 
 export const cloneRecursive = (children, newProps) => React.Children.map(children, (child) => {
   const mapProps = (child) => {

--- a/src/util_test.ts
+++ b/src/util_test.ts
@@ -71,20 +71,20 @@ describe('util', () => {
     const defaultProps = {};
 
     it(`passes when fnMap is an object with functions & component is a function that takes 1 arg`, () => {
-      expect(() => withProps(defaultFnMap, defaultComponent, defaultProps)).to.not.throw();
+      expect(() => withProps(defaultFnMap, defaultComponent)(defaultProps)).to.not.throw();
     });
 
     it('succeeds when fnMap is empty object', () => {
-      expect(() => withProps({}, defaultComponent, defaultProps)).to.not.throw();
+      expect(() => withProps({}, defaultComponent)(defaultProps)).to.not.throw();
     });
 
     it('succeeds when fnMap is object with 3 functions', () => {
       const fnMap = {
-        a: () => {},
-        b: (one, two, four) => (one + two + four),
+        a: () => 1,
+        b: ({ one, two, four }) => (one + two + four),
         c: one => one,
       };
-      expect(() => withProps(fnMap, defaultComponent, defaultProps)).to.not.throw();
+      expect(() => withProps(fnMap, defaultComponent)(defaultProps)).to.not.throw();
     });
   });
 


### PR DESCRIPTION
Adds type definitions for `withProps` so we can get rid of all the monkey-patching downstream.