### PR TITLE
Make sure README gets into the distro

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "peers": "install-self-peers -- --ignore-scripts",
-    "build": "yarn peers; rm -r ./dist; tsc; cp package.json ./dist; rollup -c",
+    "build": "yarn peers; rm -r ./dist; tsc; cp package.json ./dist; cp README.md ./dist; rollup -c",
     "lint": "NODE_ENV=test tslint -c tslint.json \"src/**/*.{js,ts,jsx,tsx}\"",
     "lint-fix": "NODE_ENV=test tslint --fix \"src/**/*.{js,ts,jsx,tsx}\"",
     "test": "./run.sh 'npm run lint' 'npm run unit-test'",


### PR DESCRIPTION
Previously, the README wasn't included in the distro which, due to an earlier NPM bug, was causing the package page to render empty.

This makes sure it's always included.