### PR TITLE
Offer strictSeq<M> function that expects its updaters to return objec…

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build/fast": "tsc; cp package.json ./dist; cp README.md ./dist; rollup -c;",
     "docs": "typedoc --json dist/api.json --mode modules --tsconfig tdconfig.json",
     "lint": "NODE_ENV=test tslint -c tslint.json --format stylish \"src/**/*.{js,ts,jsx,tsx}\"",
+    "lint/fix": "NODE_ENV=test tslint -c tslint.json --format stylish \"src/**/*.{js,ts,jsx,tsx}\" --fix",
     "test": "./run.sh 'npm run lint' 'npm run unit-test'",
     "dev": "nodemon -w src -e ts,tsx --exec yarn unit-test",
     "dev/fast": "nodemon -w src -e ts,tsx --exec yarn build/fast;",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "deep-freeze-strict": "^1.1.0",
     "js-cookie": "^2.1.4",
     "prop-types": "^15.0.0-0 || ^16.0.0-0",
-    "ramda": "^0.25.0",
+    "ramda": "^0.26.1",
     "react": "^16.2.0"
   },
   "nyc": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export * from './core';
 export { create as environment } from './environment';
-export { mergeDeep, replace, withProps, clone, cloneRecursive, log, mergeMaps, toArray } from './util';
+export { mergeDeep, replace, strictReplace, withProps, clone, cloneRecursive, log, mergeMaps, toArray } from './util';

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,7 +1,7 @@
 import * as deepFreeze from 'deep-freeze-strict';
 import {
   __, all, always, both, cond, curry, equals, evolve, filter, flip, identity,
-  ifElse, is, keys, map, merge, mergeDeepWith, not, nth, pathOr, pickAll, pipe,
+  ifElse, is, keys, map, merge, mergeDeepWith, mergeLeft, not, nth, pathOr, pickAll, pipe,
   propEq, reduce, union, when, zipWith
 } from 'ramda';
 import * as React from 'react';
@@ -28,6 +28,10 @@ export const mergeDeep = mergeDeepWith((left, right) => (
  * `[FooMessage, replace({ bar: true })]`
  */
 export const replace = flip(merge);
+
+export function strictReplace<M>(modelPartial: Partial<M>): ((model: M) => M) {
+  return mergeLeft(modelPartial);
+}
 
 /**
  * Returns the count of offsets that are equal between two arrays. Useful for determining

--- a/src/util_test.ts
+++ b/src/util_test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import 'mocha';
 import { is } from 'ramda';
-import { getValidationFailures, mergeDeep, withProps } from './util';
+import { getValidationFailures, mergeDeep, replace, strictReplace, withProps } from './util';
 
 describe('util', () => {
 
@@ -62,6 +62,32 @@ describe('util', () => {
       });
       expect(justBar.length).to.equal(1);
       expect(justBar[0]).to.equal('bar');
+    });
+  });
+
+  describe('replace', () => {
+    it('returns a function', () => {
+      expect(typeof replace({})).to.equal('function');
+    });
+
+    it('replaces stuff', () => {
+      // Note that bar could be a string or a boolean.
+      expect(replace({ foo: 1, bar: 'baz' })({ foo: 3, bar: true, guf: 'yerp' }))
+        .to.deep.equal({ foo: 1, bar: 'baz', guf: 'yerp' });
+    });
+  });
+
+  describe('strictReplace', () => {
+    type FooBarGuf = {
+      foo: number,
+      bar: string,
+      guf: string,
+    };
+    it('does the same thing as replace, but takes a parameterize type', () => {
+      // Note that bar has to be the same type in both the source and destination objects,
+      // otherwise this wouldn't compile!
+      expect(strictReplace<FooBarGuf>({ foo: 1, bar: 'baz' })({ foo: 3, bar: 'true', guf: 'yerp' }))
+        .to.deep.equal({ foo: 1, bar: 'baz', guf: 'yerp' });
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -566,12 +566,12 @@ aws4@^1.8.0:
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
 "axios@^0.16.0 || ^0.17.0 || ^0.18.0":
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
-  integrity sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=
+  version "0.18.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.1.tgz#ff3f0de2e7b5d180e757ad98000f1081b87bcea3"
+  integrity sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==
   dependencies:
-    follow-redirects "^1.3.0"
-    is-buffer "^1.1.5"
+    follow-redirects "1.5.10"
+    is-buffer "^2.0.2"
 
 babel-code-frame@^6.22.0:
   version "6.26.0"
@@ -1042,7 +1042,7 @@ debug-log@^1.0.1:
   resolved "https://registry.yarnpkg.com/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"
   integrity sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=
 
-debug@3.1.0:
+debug@3.1.0, debug@=3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
@@ -1056,7 +1056,7 @@ debug@^2.1.2, debug@^2.2.0, debug@^2.3.3:
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.0, debug@^3.2.6:
+debug@^3.1.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -1518,12 +1518,12 @@ find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
-follow-redirects@^1.3.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.7.0.tgz#489ebc198dc0e7f64167bd23b03c4c19b5784c76"
-  integrity sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
   dependencies:
-    debug "^3.2.6"
+    debug "=3.1.0"
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
@@ -1974,6 +1974,11 @@ is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
+
+is-buffer@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.3.tgz#4ecf3fcf749cbd1e472689e109ac66261a25e725"
+  integrity sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==
 
 is-builtin-module@^1.0.0:
   version "1.0.0"
@@ -3348,10 +3353,10 @@ ramda@^0.23.0:
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.23.0.tgz#ccd13fff73497a93974e3e86327bfd87bd6e8e2b"
   integrity sha1-zNE//3NJepOXTj6GMnv9h71ujis=
 
-ramda@^0.25.0:
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
-  integrity sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ==
+ramda@^0.26.1:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
+  integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
 
 randexp@0.4.6:
   version "0.4.6"


### PR DESCRIPTION
…ts with a shape of

{ model: M, msg?: Message[] } to better leverage the TypeScript compiler without annoyances.
Similar helper added strictReplace.
Idea is that eventually the stricts would go away in a major version bump when they replace
the non-strict versions.

https://trello.com/c/L08isSc0/683-okr-offer-stricter-option-to-casium-seq-function