### PR TITLE
Upgrade equals comparisons

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,5 +78,8 @@
       "html",
       "lcov"
     ]
+  },
+  "dependencies": {
+    "@ailabs/fast-deep-equal": "3.2.1"
   }
 }

--- a/src/containers/input.tsx
+++ b/src/containers/input.tsx
@@ -15,7 +15,7 @@ export default container({
   delegate: PARENT,
 
   update: [
-    [Change, (state, { name, value }) => assoc(name, value, state)],
+    [Change, (state: any, { name, value }) => assoc(name, value, state)],
   ],
 
   view: withProps({ name }, ({ emit, name, children, ...props }: any) => (

--- a/src/dispatcher_test.ts
+++ b/src/dispatcher_test.ts
@@ -10,7 +10,7 @@ describe('dispatcher', () => {
 
   describe('handler()', () => {
 
-    class Msg extends Message {}
+    class Msg extends Message { }
 
     it('returns the message constructor when a match is found', () => {
       expect(handler(effects, new Read({ key: 'foo', result: Msg }))).to.deep.equal(Read);
@@ -23,13 +23,16 @@ describe('dispatcher', () => {
 
   describe('dispatcher()', () => {
     it('throws when dispatching invalid input', () => {
-      expect(() => dispatcher(new Map([]), {}, {})).to.throw(TypeError, /type 'Object' is not acceptable/);
+      expect(() => dispatcher(new Map([]) as any, {} as any, {} as any)).to.throw(
+        TypeError,
+        /type 'Object' is not acceptable/
+      );
     });
 
     it('throws when dispatching an unhandled message', () => {
-      class Msg extends Message {}
+      class Msg extends Message { }
 
-      expect(() => dispatcher(new Map([]), {}, new Msg())).to.throw(TypeError, /Unhandled/);
+      expect(() => dispatcher(new Map([]) as any, {} as any, new Msg())).to.throw(TypeError, /Unhandled/);
     });
 
   });

--- a/src/effects/index.ts
+++ b/src/effects/index.ts
@@ -1,3 +1,5 @@
+import { CommandDispatcher, SubscriptionDispatcher } from '../environment';
+import { MessageConstructor } from '../message';
 import { mergeMaps } from '../util';
 
 import browser from './browser';
@@ -5,4 +7,7 @@ import cookies from './cookies';
 import http from './http';
 import localStorage from './local_storage';
 
-export default mergeMaps([http, browser, cookies, localStorage]);
+export default (
+  mergeMaps([http, browser, cookies, localStorage]) as
+  Map<MessageConstructor, CommandDispatcher | SubscriptionDispatcher>
+);

--- a/src/effects/local_storage.ts
+++ b/src/effects/local_storage.ts
@@ -14,9 +14,9 @@ const get = (() => {
 })();
 
 export default new Map([
-  [Read, ({ key, result }, dispatch) => pipe(
+  [Read, ({ key, result }, dispatch) => (pipe(
     get, safeParse, objOf('value'), merge({ key }), Message.construct(result), dispatch
-  )(key)],
+  ) as any)(key)],
   [Write, ({ key, value }) => window.localStorage.setItem(key, safeStringify(value))],
   [Delete, ({ key }) => window.localStorage.removeItem(key)],
   [Clear, () => window.localStorage.clear()],

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -73,7 +73,11 @@ export const root: Environment = create({ effects, dispatcher: coreDispatcher, d
 /**
  * Helper function for `create()`, to merge effects maps
  */
-const mergeWithEffects = mergeDeepWithKey((key, left, right) => key === 'effects' ? mergeMap(left, right) : right);
+const mergeWithEffects = mergeDeepWithKey((key, left, right) => (
+  key === 'effects'
+    ? mergeMap(left as any, right as any)
+    : right
+));
 
 /**
  * Helper function for `create()`. Validates state of environments.
@@ -89,12 +93,12 @@ const checkEnvChain = <M>(parent?: ExecContext<M> | ExecContextPartial, env?: En
 export const merge: <M>(parent?: ExecContext<M> | ExecContextPartial, env?: Environment) => Environment = pipe(
   checkEnvChain,
   cond([
-    [prop('canMerge'), ({ parent, env }) => create({
+    [prop('canMerge'), ({ parent, env }: any) => create({
       ...mergeWithEffects(parent.env.identity(), env.identity()),
       displayError: env.displayError && env.displayError !== Error ? env.displayError : parent.env.displayError
-    })],
+    } as any)],
     [prop('hasOnlyParent'), path(['parent', 'env'])],
     [prop('isOnlyChild'), prop('env')],
     [T, always(root)]
-  ])
+  ]) as any
 );

--- a/src/message.ts
+++ b/src/message.ts
@@ -32,7 +32,7 @@ export default class Message {
   /**
    * Checks that a value is emittable as a message constructor
    */
-  public static isEmittable = or(Message.is, both(is(Array), pipe(nth(0), Message.is)));
+  public static isEmittable = or(Message.is, both(is(Array), pipe(nth(0), Message.is) as any));
 
   public static toEmittable = ifElse(is(Array), identity, type => [type, {}]);
 
@@ -72,9 +72,9 @@ export default class Message {
     throw new Error(`Message data must be an object in message ${ctor.name} but is ${safeStringify(data)}`);
   }
 
- /**
-  * Maps an Event object to a hash that will be wrapped in a Message.
-  */
+  /**
+   * Maps an Event object to a hash that will be wrapped in a Message.
+   */
   public static mapEvent = curry((extra: object & { preventDefault?: boolean }, event: Event) => {
     const target = event.target as HTMLInputElement;
     const isDomEvent = event && (event as any).nativeEvent && is(Object, target);

--- a/src/runtime/exec_context.ts
+++ b/src/runtime/exec_context.ts
@@ -99,7 +99,7 @@ const mapMessage = (handler, state, msg, relay) => {
  */
 const checkCmdMsgs = curry(<M>(exec: ExecContext<M>, cmd: Message) => {
   const unhandled = pipe(prop('data'), values, filter(Message.isEmittable), filter(not(exec.handles)));
-  const msgs = unhandled(cmd);
+  const msgs = unhandled(cmd) as MessageConstructor[];
 
   if (!msgs.length) {
     return cmd;
@@ -192,7 +192,7 @@ export default class ExecContext<M> {
         hasInitialized = true;
         const { attach } = container, hasStore = attach && attach.store;
         const initial = hasStore ? attachStore(container.attach, this) : (this.getState() || {});
-        run(null, mapResult((container.init || identity)(initial, parent && parent.relay() || {}) || {}));
+        run(null, mapResult((container.init || identity)(initial, parent && parent.relay() || {}) || {}) as [any, any]);
       }
       return fn.call(this, ...args);
     };

--- a/src/util.ts
+++ b/src/util.ts
@@ -18,8 +18,8 @@ export const moduleName = (prefix: string) => (constructor: Function) => {
  * @param  {Object} right
  * @return {Object}
  */
-export const mergeDeep = mergeDeepWith((left, right) => (
-  all(is(Array), [left, right]) ? union(left, right) : right
+export const mergeDeep = mergeDeepWith(<A>(left: A, right: A) => (
+  all(is(Array), [left, right]) ? union(left as any as A[], right as any as A[]) : right
 ));
 
 /**
@@ -42,7 +42,7 @@ export const replace = flip(merge);
  * @param  {Array} b Array to compare against
  * @return {Boolean} Returns true if `a` is the prefix of `b`.
  */
-export const compareOffsets = curry((a, b) => all(equals(true), zipWith(equals, a, b)));
+export const compareOffsets = curry((a, b) => all(equals(true), zipWith(equals, a, b) as any));
 
 /**
  * Accepts a validator object where the values are functions that return boolean, and
@@ -91,7 +91,10 @@ export function withProps<Input, Generated>(
   fnMap: PropMap<Input, Generated>,
   component: React.StatelessComponent<Input & Generated>
 ) {
-  return (props: Input) => component(merge(props, map(fn => fn(props), fnMap)) as Input & Generated);
+  return (props: Input) => component(merge(
+    props,
+    map(fn => fn(props), fnMap)
+  ) as unknown as Input & Generated);
 }
 
 export const cloneRecursive = (children, newProps) => React.Children.map(children, (child) => {
@@ -191,7 +194,7 @@ const freezeObj = when(is(Object), deepFreeze);
  */
 export const mapResult = cond([
   [both(is(Array), propEq('length', 0)), () => { throw new TypeError('An empty array is an invalid value'); }],
-  [both(is(Array), propEq('length', 1)), ([state]) => [freezeObj(state), []]],
+  [both(is(Array), propEq('length', 1)), ([state]: any) => [freezeObj(state), []]],
   [is(Array), ([state, ...commands]) => [freezeObj(state), commands]],
   [is(Object), state => [freezeObj(state), []]],
   [always(true), (val) => { throw new TypeError(`Unrecognized structure ${safeStringify(val)}`); }],

--- a/src/view_wrapper.tsx
+++ b/src/view_wrapper.tsx
@@ -1,5 +1,6 @@
+import * as equals from '@ailabs/fast-deep-equal/react';
 import * as PropTypes from 'prop-types';
-import { equals, keys, merge, mergeAll, omit, pick, pipe } from 'ramda';
+import { keys, merge, mergeAll, omit, pick, pipe } from 'ramda';
 import * as React from 'react';
 import { Container, DelegateDef } from './core';
 import { Environment } from './environment';
@@ -86,7 +87,7 @@ export default class ViewWrapper<M> extends React.Component<ViewWrapperProps<M>,
   public componentDidUpdate(prev) {
     const { childProps } = this.props;
     const omitChildren = omit(['children']);
-    if (!equals(omitChildren(prev.childProps), omitChildren(childProps))) {
+    if (!equals(omitChildren(prev.childProps), omitChildren(childProps as any))) {
       this.dispatchLifecycleMessage(Refresh, this.props);
     }
   }
@@ -118,7 +119,11 @@ export default class ViewWrapper<M> extends React.Component<ViewWrapperProps<M>,
     }
     // tslint:disable-next-line:variable-name
     const Child = (this.props.container as any).view, ctx = this.execContext;
-    const props = mergeAll([this.props.childProps, ctx.state(), { emit: ctx.emit.bind(ctx), relay: ctx.relay() }]);
+    const props = mergeAll([
+      this.props.childProps as any,
+      ctx.state(),
+      { emit: ctx.emit.bind(ctx), relay: ctx.relay() }
+    ]);
     return <Child {...props} />;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@ailabs/fast-deep-equal@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@ailabs/fast-deep-equal/-/fast-deep-equal-3.2.1.tgz#c88ea0b723f91ed9b4cd089a13e32d133bdf6618"
+  integrity sha512-xlPxqKMMgSY9odtp2hULdVjxm5iD6YQaV7jm3iFR3n3EJ5RYwxiGGoEqmYBw8dsEs+nexosWe4g13lcoJjNT/w==
+
 "@babel/code-frame@7.0.0-beta.51":
   version "7.0.0-beta.51"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.51.tgz#bd71d9b192af978df915829d39d4094456439a0c"


### PR DESCRIPTION
In addition to being quite slow, Ramda's `equals` implementation can't handle symbol keys. This PR pulls in a forked version of `fast-deep-equals` which _can_ handle symbol keys. Incidentally it's also pretty fast:

```
fast-deep-equal x 208,559 ops/sec ±1.57% (86 runs sampled)
fast-deep-equal/es6 x 82,924 ops/sec ±0.52% (87 runs sampled)
fast-equals x 192,611 ops/sec ±3.52% (85 runs sampled)
nano-equal x 160,518 ops/sec ±0.65% (91 runs sampled)
shallow-equal-fuzzy x 141,525 ops/sec ±0.50% (89 runs sampled)
underscore.isEqual x 95,010 ops/sec ±0.61% (90 runs sampled)
lodash.isEqual x 32,457 ops/sec ±0.57% (89 runs sampled)
deep-equal x 175 ops/sec ±1.87% (52 runs sampled)
deep-eql x 33,933 ops/sec ±0.57% (92 runs sampled)
ramda.equals x 10,357 ops/sec ±0.49% (85 runs sampled)
util.isDeepStrictEqual x 50,610 ops/sec ±0.33% (89 runs sampled)
assert.deepStrictEqual x 895 ops/sec ±0.52% (83 runs sampled)
```