### PR TITLE
Allow setting axios responseType via HTTP Request

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casium",
-  "version": "2.2.4",
+  "version": "2.3.0",
   "description": "Casium — An application architecture for React",
   "module": "./index.js",
   "browser": "dist/casium.umd.js",

--- a/src/commands/http.ts
+++ b/src/commands/http.ts
@@ -1,4 +1,4 @@
-import { either as or, is, keys } from 'ramda';
+import { either as or, is, isNil, keys } from 'ramda';
 import Message from '../message';
 import { moduleName } from '../util';
 
@@ -8,13 +8,13 @@ type Defaults = {
   data: {},
   params: {},
   headers: {},
-  responseType: string | null | undefined,
+  responseType: string | undefined,
 };
 
 @moduleName('HTTP')
 export class Request extends Message {
   public static defaults: Defaults =
-    { method: null, url: null, data: {}, params: {}, headers: {}, responseType: 'json' };
+    { method: null, url: null, data: {}, params: {}, headers: {}, responseType: undefined };
 
   public static expects = {
     method: is(String),
@@ -24,50 +24,50 @@ export class Request extends Message {
     headers: is(Object),
     result: Message.isEmittable,
     error: Message.isEmittable,
-    responseType: is(String),
+    responseType: or(is(String), isNil)
   };
 }
 
 @moduleName('HTTP')
 export class Post extends Request {
   public static defaults: Defaults =
-    { method: 'POST', url: null, data: {}, params: {}, headers: {}, responseType: 'json' };
+    { method: 'POST', url: null, data: {}, params: {}, headers: {}, responseType: undefined };
 }
 
 @moduleName('HTTP')
 export class Get extends Request {
   public static defaults: Defaults =
-    { method: 'GET', url: null, data: {}, params: {}, headers: {}, responseType: 'json' };
+    { method: 'GET', url: null, data: {}, params: {}, headers: {}, responseType: undefined };
 }
 
 @moduleName('HTTP')
 export class Put extends Request {
   public static defaults: Defaults =
-    { method: 'PUT', url: null, data: {}, params: {}, headers: {}, responseType: 'json' };
+    { method: 'PUT', url: null, data: {}, params: {}, headers: {}, responseType: undefined };
 }
 
 @moduleName('HTTP')
 export class Head extends Request {
   public static defaults: Defaults =
-    { method: 'HEAD', url: null, data: {}, params: {}, headers: {}, responseType: 'json' };
+    { method: 'HEAD', url: null, data: {}, params: {}, headers: {}, responseType: undefined };
 }
 
 @moduleName('HTTP')
 export class Delete extends Request {
   public static defaults: Defaults =
-    { method: 'DELETE', url: null, data: {}, params: {}, headers: {}, responseType: 'json' };
+    { method: 'DELETE', url: null, data: {}, params: {}, headers: {}, responseType: undefined };
 }
 
 @moduleName('HTTP')
 export class Options extends Request {
   public static defaults: Defaults =
-    { method: 'OPTIONS', url: null, data: {}, params: {}, headers: {}, responseType: 'json' };
+    { method: 'OPTIONS', url: null, data: {}, params: {}, headers: {}, responseType: undefined };
 }
 
 @moduleName('HTTP')
 export class Patch extends Request {
   public static defaults: Defaults =
-    { method: 'PATCH', url: null, data: {}, params: {}, headers: {}, responseType: 'json' };
+    { method: 'PATCH', url: null, data: {}, params: {}, headers: {}, responseType: undefined };
 }
 
 export const formData = data =>

--- a/src/commands/http.ts
+++ b/src/commands/http.ts
@@ -8,11 +8,13 @@ type Defaults = {
   data: {},
   params: {},
   headers: {},
+  responseType: string | null | undefined,
 };
 
 @moduleName('HTTP')
 export class Request extends Message {
-  public static defaults: Defaults = { method: null, url: null, data: {}, params: {}, headers: {} };
+  public static defaults: Defaults =
+    { method: null, url: null, data: {}, params: {}, headers: {}, responseType: 'json' };
 
   public static expects = {
     method: is(String),
@@ -22,42 +24,50 @@ export class Request extends Message {
     headers: is(Object),
     result: Message.isEmittable,
     error: Message.isEmittable,
+    responseType: is(String),
   };
 }
 
 @moduleName('HTTP')
 export class Post extends Request {
-  public static defaults = { method: 'POST', url: null, data: {}, params: {}, headers: {} };
+  public static defaults: Defaults =
+    { method: 'POST', url: null, data: {}, params: {}, headers: {}, responseType: 'json' };
 }
 
 @moduleName('HTTP')
 export class Get extends Request {
-  public static defaults = { method: 'GET', url: null, data: {}, params: {}, headers: {} };
+  public static defaults: Defaults =
+    { method: 'GET', url: null, data: {}, params: {}, headers: {}, responseType: 'json' };
 }
 
 @moduleName('HTTP')
 export class Put extends Request {
-  public static defaults = { method: 'PUT', url: null, data: {}, params: {}, headers: {} };
+  public static defaults: Defaults =
+    { method: 'PUT', url: null, data: {}, params: {}, headers: {}, responseType: 'json' };
 }
 
 @moduleName('HTTP')
 export class Head extends Request {
-  public static defaults = { method: 'HEAD', url: null, data: {}, params: {}, headers: {} };
+  public static defaults: Defaults =
+    { method: 'HEAD', url: null, data: {}, params: {}, headers: {}, responseType: 'json' };
 }
 
 @moduleName('HTTP')
 export class Delete extends Request {
-  public static defaults = { method: 'DELETE', url: null, data: {}, params: {}, headers: {} };
+  public static defaults: Defaults =
+    { method: 'DELETE', url: null, data: {}, params: {}, headers: {}, responseType: 'json' };
 }
 
 @moduleName('HTTP')
 export class Options extends Request {
-  public static defaults = { method: 'OPTIONS', url: null, data: {}, params: {}, headers: {} };
+  public static defaults: Defaults =
+    { method: 'OPTIONS', url: null, data: {}, params: {}, headers: {}, responseType: 'json' };
 }
 
 @moduleName('HTTP')
 export class Patch extends Request {
-  public static defaults = { method: 'PATCH', url: null, data: {}, params: {}, headers: {} };
+  public static defaults: Defaults =
+    { method: 'PATCH', url: null, data: {}, params: {}, headers: {}, responseType: 'json' };
 }
 
 export const formData = data =>

--- a/src/effects/http.ts
+++ b/src/effects/http.ts
@@ -4,20 +4,8 @@ import { Request } from '../commands/http';
 import Message from '../message';
 
 export default new Map([[Request,
-  ({
-     method,
-     url,
-     data,
-     params,
-     headers,
-     result,
-     error,
-     always,
-     responseType = 'json',
-     withCredentials = true,
-   },
-   dispatch) => {
-    axios({ method, url, data, params, headers, responseType, withCredentials })
+  ({ method, url, data, params, headers, result, error, always, responseType, withCredentials = true, }, dispatch) => {
+    axios({ method, url, data, params, headers, responseType, withCredentials, })
       .then(pipe(Message.construct(result), dispatch))
       .catch(pipe(Message.construct(error), dispatch))
       .then(always && pipe(Message.construct(always), dispatch) || identity);

--- a/src/effects/http.ts
+++ b/src/effects/http.ts
@@ -3,9 +3,21 @@ import { identity, pipe } from 'ramda';
 import { Request } from '../commands/http';
 import Message from '../message';
 
-export default new Map([
-  [Request, ({ method, url, data, params, headers, result, error, always, withCredentials = true }, dispatch) => {
-    axios({ method, url, data, params, headers, withCredentials })
+export default new Map([[Request,
+  ({
+     method,
+     url,
+     data,
+     params,
+     headers,
+     result,
+     error,
+     always,
+     responseType = 'json',
+     withCredentials = true,
+   },
+   dispatch) => {
+    axios({ method, url, data, params, headers, responseType, withCredentials })
       .then(pipe(Message.construct(result), dispatch))
       .catch(pipe(Message.construct(error), dispatch))
       .then(always && pipe(Message.construct(always), dispatch) || identity);

--- a/src/effects/http.ts
+++ b/src/effects/http.ts
@@ -4,8 +4,8 @@ import { Request } from '../commands/http';
 import Message from '../message';
 
 export default new Map([[Request,
-  ({ method, url, data, params, headers, result, error, always, responseType, withCredentials = true, }, dispatch) => {
-    axios({ method, url, data, params, headers, responseType, withCredentials, })
+  ({ method, url, data, params, headers, result, error, always, responseType, withCredentials = true }, dispatch) => {
+    axios({ method, url, data, params, headers, responseType, withCredentials })
       .then(pipe(Message.construct(result), dispatch))
       .catch(pipe(Message.construct(error), dispatch))
       .then(always && pipe(Message.construct(always), dispatch) || identity);


### PR DESCRIPTION
Allows setting Axios' `responseType` field in the request config

[Request Config](https://github.com/axios/axios/blob/master/README.md#request-config):
> `responseType` indicates the type of data that the server will respond with options are: 'arraybuffer', 'document', 'json', 'text', 'stream'
> browser only: 'blob'